### PR TITLE
Add highlight animation and reload functionality for postal codes

### DIFF
--- a/html/scripts/lasso.js
+++ b/html/scripts/lasso.js
@@ -1,4 +1,4 @@
-import { disablePostalCodeClicks, enablePostalCodeClicks, addAllPostalCodes } from './postalCodeManager.js';
+import { disablePostalCodeClicks, enablePostalCodeClicks, addAllPostalCodes, reloadSelectedPostalCodes } from './postalCodeManager.js';
 
 export let isLassoActive = false;
 let currentMode; // Add this line to keep track of the current mode
@@ -236,6 +236,7 @@ function endLasso(e) {
     selectPathsInLasso();
     updateDebugCounters(); // Update counters one last time
     clearLasso();
+    reloadSelectedPostalCodes(); // Add this line to reload selected postal codes after lasso selection
     // Remove debug points after a short delay
     setTimeout(() => {
         const debugGroup = svgElement.querySelector('#debug-points');

--- a/html/scripts/mapLoader.js
+++ b/html/scripts/mapLoader.js
@@ -1,6 +1,6 @@
 const TOGGLE_STATES_COOKIE = 'countryToggleStates';
 
-function getColorVariation(color, factor) {
+export function getColorVariation(color, factor) {
     // Convert hex color to RGB
     const r = parseInt(color.slice(1, 3), 16);
     const g = parseInt(color.slice(3, 5), 16);

--- a/html/scripts/postalCodeManager.js
+++ b/html/scripts/postalCodeManager.js
@@ -1,4 +1,5 @@
 import { isPointInPolygon, setLassoMode, isLassoActive } from './lasso.js';
+import { getColorVariation } from './mapLoader.js'; // Add this import
 
 const LOADING_MODE = 'loading';
 const DELIVERY_MODE = 'delivery';
@@ -443,10 +444,25 @@ document.getElementById('delivery-color').addEventListener('input', (e) => {
 // Function to update postal code selection color
 function updatePostalCodeSelectionColor(mode, color) {
     const postalCodes = mode === 'loading' ? loadingPostalCodes : deliveryPostalCodes;
+    const countryColors = new Map();
+
     postalCodes.forEach(postalCode => {
         const pathElement = document.getElementById(postalCode);
         if (pathElement) {
-            pathElement.style.fill = color; // Update the fill color of the postal code
+            const parentGroup = pathElement.closest('g');
+            const country = parentGroup ? parentGroup.id : 'Unknown';
+            if (!countryColors.has(country)) {
+                countryColors.set(country, getColorVariation(color, 0.7 + (Math.random() * 0.3)));
+            }
+            pathElement.style.fill = countryColors.get(country); // Update the fill color of the postal code
         }
+    });
+}
+
+export function reloadSelectedPostalCodes() {
+    loadSelectedPostalCodes().then(() => {
+        console.log('Selected postal codes reloaded.');
+    }).catch(error => {
+        console.error('Error reloading selected postal codes:', error);
     });
 }

--- a/html/scripts/postalCodeManager.js
+++ b/html/scripts/postalCodeManager.js
@@ -257,10 +257,13 @@ function highlightPostalCode(postalCode, highlight) {
             pathElement.style.stroke = '#ff0000';
             pathElement.style.strokeWidth = '2px';
             pathElement.style.fillOpacity = '0.7';
+            pathElement.style.animation = 'highlight 1s infinite';
         } else {
             pathElement.style.stroke = '';
             pathElement.style.strokeWidth = '';
             pathElement.style.fillOpacity = '';
+            pathElement.style.animation = '';
+
         }
     }
 }

--- a/html/styles/styles.css
+++ b/html/styles/styles.css
@@ -1,4 +1,5 @@
-body, html {
+body,
+html {
     margin: 0;
     padding: 0;
     font-family: 'Roboto', sans-serif;
@@ -366,40 +367,59 @@ path.selected.delivery {
 .remove-country-btn:hover {
     color: #c82333;
 }
+
 .color-picker {
     /* display: none; Hide the default color input */
 }
 
 #mode-toggle button {
     position: relative;
-    padding-right: 30px; /* Add padding to the right for the color picker */
+    padding-right: 30px;
+    /* Add padding to the right for the color picker */
 }
 
 #mode-toggle button .color-picker {
     position: absolute;
     top: 50%;
-    right: 10px; /* Position it on the right */
-    transform: translateY(-50%); /* Center vertically */
-    width: 20px; /* Adjust size as needed */
-    height: 20px; /* Adjust size as needed */
+    right: 10px;
+    /* Position it on the right */
+    transform: translateY(-50%);
+    /* Center vertically */
+    width: 20px;
+    /* Adjust size as needed */
+    height: 20px;
+    /* Adjust size as needed */
     /* border-radius: 50%; Make it a circle */
-    border: none; /* Remove border */
-    background-color: currentColor; /* Fill with the button's text color */
+    border: none;
+    /* Remove border */
+    background-color: currentColor;
+    /* Fill with the button's text color */
 }
+
 #zoom-factor {
-    display: flex; /* Use flexbox for centering */
-    align-items: center; /* Center vertically */
-    justify-content: center; /* Center horizontally */
-    padding: 0 1rem; /* Add some padding for better spacing */
-    font-weight: 500; /* Optional: make the text bolder */
+    display: flex;
+    /* Use flexbox for centering */
+    align-items: center;
+    /* Center vertically */
+    justify-content: center;
+    /* Center horizontally */
+    padding: 0 1rem;
+    /* Add some padding for better spacing */
+    font-weight: 500;
+    /* Optional: make the text bolder */
 }
 
 #lasso-status {
-    display: flex; /* Use flexbox for centering */
-    align-items: center; /* Center vertically */
-    justify-content: center; /* Center horizontally */
-    padding: 0 1rem; /* Add some padding for better spacing */
-    font-weight: 500; /* Optional: make the text bolder */
+    display: flex;
+    /* Use flexbox for centering */
+    align-items: center;
+    /* Center vertically */
+    justify-content: center;
+    /* Center horizontally */
+    padding: 0 1rem;
+    /* Add some padding for better spacing */
+    font-weight: 500;
+    /* Optional: make the text bolder */
 }
 
 
@@ -407,35 +427,52 @@ path.selected.delivery {
 #region-select {
     display: flex;
     align-items: center;
-    background-color: white; /* Match the background of zoom-controls */
-    border-radius: 25px; /* Match the border radius */
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1); /* Match the shadow */
-    padding: 0.5rem; /* Add padding for spacing */
-    margin-left: 1rem; /* Add margin to separate from zoom controls */
+    background-color: white;
+    /* Match the background of zoom-controls */
+    border-radius: 25px;
+    /* Match the border radius */
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    /* Match the shadow */
+    padding: 0.5rem;
+    /* Add padding for spacing */
+    margin-left: 1rem;
+    /* Add margin to separate from zoom controls */
 }
 
 #region-select label {
-    margin-right: 0.5rem; /* Space between label and select */
+    margin-right: 0.5rem;
+    /* Space between label and select */
 }
 
 #region-select select {
-    border: none; /* Remove default border */
-    padding: 0.5rem; /* Add padding for better appearance */
-    font-size: 1rem; /* Match font size */
-    color: #2980b9; /* Match text color */
-    background-color: transparent; /* Make background transparent */
-    cursor: pointer; /* Change cursor to pointer */
+    border: none;
+    /* Remove default border */
+    padding: 0.5rem;
+    /* Add padding for better appearance */
+    font-size: 1rem;
+    /* Match font size */
+    color: #2980b9;
+    /* Match text color */
+    background-color: transparent;
+    /* Make background transparent */
+    cursor: pointer;
+    /* Change cursor to pointer */
 }
 
 .no-select {
-    user-select: none; /* For modern browsers */
-    -webkit-user-select: none; /* For Safari */
-    -moz-user-select: none; /* For Firefox */
-    -ms-user-select: none; /* For Internet Explorer/Edge */
+    user-select: none;
+    /* For modern browsers */
+    -webkit-user-select: none;
+    /* For Safari */
+    -moz-user-select: none;
+    /* For Firefox */
+    -ms-user-select: none;
+    /* For Internet Explorer/Edge */
 }
 
 #region-select select:hover {
-    background-color: #ecf0f1; /* Change background on hover */
+    background-color: #ecf0f1;
+    /* Change background on hover */
 }
 
 /* .lasso-active {
@@ -452,7 +489,8 @@ path.selected.delivery {
 }
 
 .greyed-out {
-    color: #b0b0b0; /* Light grey color */
+    color: #b0b0b0;
+    /* Light grey color */
 }
 
 /* Country list styles */
@@ -512,11 +550,11 @@ path.selected.delivery {
     border-radius: 50%;
 }
 
-input:checked + .slider {
+input:checked+.slider {
     background-color: #2196F3;
 }
 
-input:checked + .slider:before {
+input:checked+.slider:before {
     transform: translateX(20px);
 }
 
@@ -549,18 +587,23 @@ input:checked + .slider:before {
 }
 
 #map-container {
-    cursor: grab; /* Default cursor when not using lasso */
+    cursor: grab;
+    /* Default cursor when not using lasso */
 }
 
 #map-container:active {
-    cursor: grabbing; /* Cursor when the mouse is pressed down */
+    cursor: grabbing;
+    /* Cursor when the mouse is pressed down */
 }
+
 #map-container.lasso-active {
-    cursor: crosshair; /* Change to your desired cursor style */
+    cursor: crosshair;
+    /* Change to your desired cursor style */
 }
 
 path.postal-code {
-    cursor: pointer; /* Change cursor to pointer for postal codes */
+    cursor: pointer;
+    /* Change cursor to pointer for postal codes */
 }
 
 /* Add styles for the loader element */
@@ -590,6 +633,21 @@ path.postal-code {
 }
 
 @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes highlight {
+    0% {
+        filter: brightness(150%);
+    }
+
+    50% {
+        filter: brightness(300%);
+    }
 }


### PR DESCRIPTION
Introduce a highlight animation for postal codes and implement a reload feature for selected postal codes, enhancing user interaction and visual feedback. Improve CSS formatting for better readability and maintainability.

closes #31