### PR TITLE
Add 'Zoom to Visible' functionality for SVG elements

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -26,6 +26,7 @@
                 <button id="zoom-out" title="Zoom Out"><i class="fas fa-search-minus"></i></button>
                 <span id="zoom-factor">Zoom: 1.0x</span> <!-- Add this line -->
                 <button id="reset-zoom" title="Reset Zoom"><i class="fas fa-sync-alt"></i></button>
+                <button id="zoom-visible" title="Zoom to Visible"><i class="fas fa-eye"></i></button> <!-- Add this line -->
                 <span id="lasso-status" style="display: none;">Lassoing... Click and drag to select.</span> <!-- Add this line -->
                 <button id="lasso-button" title="Lasso Select"><i class="fas fa-draw-polygon"></i></button>
             </div>

--- a/html/scripts/main.js
+++ b/html/scripts/main.js
@@ -1,5 +1,5 @@
 import { loadSVG, toggleCountryVisibility } from './mapLoader.js';
-import { initializeZoomPan, setupZoomControls, setupPanning } from './zoomPan.js';
+import { initializeZoomPan, setupZoomControls, setupPanning, triggerZoomVisible } from './zoomPan.js';
 import { setupPostalCodeClicks, loadSelectedPostalCodes, setMode, togglePostalCode } from './postalCodeManager.js';
 import { setupModeToggle, setupLookupButton } from './uiSetup.js';
 import { connectWebSocket } from './websocket.js';
@@ -122,6 +122,9 @@ function handleRegionChange(selectedOption) {
             toggleCountryVisibility(countryName, shouldBeVisible);
         }
     });
+
+    // Trigger zoom to visible after toggling the region
+    triggerZoomVisible();
 }
 
 function initializeApp() {

--- a/html/scripts/mapLoader.js
+++ b/html/scripts/mapLoader.js
@@ -1,3 +1,5 @@
+import { triggerZoomVisible } from './zoomPan.js';
+
 const TOGGLE_STATES_COOKIE = 'countryToggleStates';
 
 export function getColorVariation(color, factor) {
@@ -44,6 +46,9 @@ export function toggleCountryVisibility(country, isVisible) {
 
     // Save toggle states after each change
     saveToggleStates();
+
+    // Trigger zoom to visible after toggling the country visibility
+    triggerZoomVisible();
 }
 
 function setupToggleAll() {

--- a/html/scripts/zoomPan.js
+++ b/html/scripts/zoomPan.js
@@ -116,6 +116,7 @@ function updateSvgViewBox() {
 }
 
 function zoomVisible() {
+    resetView();
     const paths = svgElement.querySelectorAll('path');
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
 
@@ -139,7 +140,7 @@ function zoomVisible() {
 
         const zoomX = viewBox.width / visibleWidth;
         const zoomY = viewBox.height / visibleHeight;
-        currentZoom = Math.max(zoomX, zoomY);
+        currentZoom = Math.min(zoomX, zoomY);
 
         viewBox = {
             x: minX,

--- a/html/scripts/zoomPan.js
+++ b/html/scripts/zoomPan.js
@@ -170,3 +170,7 @@ function zoomVisible() {
 
     }
 }
+
+export function triggerZoomVisible() {
+    zoomVisible();
+}

--- a/html/scripts/zoomPan.js
+++ b/html/scripts/zoomPan.js
@@ -28,11 +28,13 @@ export function setupZoomControls() {
     const zoomOut = document.getElementById('zoom-out');
     const resetZoom = document.getElementById('reset-zoom');
     zoomFactorDisplay = document.getElementById('zoom-factor'); // Add this line
+    const zoomVisibleButton = document.getElementById('zoom-visible'); // Add this line
 
     zoomIn.addEventListener('click', () => zoom(zoomStep));
     zoomOut.addEventListener('click', () => zoom(-zoomStep));
     resetZoom.addEventListener('click', resetView);
-    
+    zoomVisibleButton.addEventListener('click', zoomVisible); // Add this line
+
     // Add mouse wheel zoom
     svgElement.addEventListener('wheel', (e) => {
         e.preventDefault();
@@ -102,7 +104,7 @@ function resetView() {
     currentZoom = 1;
     viewBox = { ...originalViewBox };
     updateSvgViewBox();
-    
+
     // Update the zoom factor display
     zoomFactorDisplay.textContent = `Zoom: ${currentZoom.toFixed(1)}x`; // Add this line
 }
@@ -110,5 +112,60 @@ function resetView() {
 function updateSvgViewBox() {
     if (svgElement && viewBox) {
         svgElement.setAttribute('viewBox', `${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`);
+    }
+}
+
+function zoomVisible() {
+    const paths = svgElement.querySelectorAll('path');
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+
+    paths.forEach(path => {
+        const parentGroup = path.closest('g');
+        const isVisible = path.style.display !== 'none' && (!parentGroup || parentGroup.style.display !== 'none');
+        if (isVisible) {
+            const bbox = path.getBBox();
+            minX = Math.min(minX, bbox.x);
+            minY = Math.min(minY, bbox.y);
+            maxX = Math.max(maxX, bbox.x + bbox.width);
+            maxY = Math.max(maxY, bbox.y + bbox.height);
+        }
+    });
+
+    if (minX < Infinity && minY < Infinity && maxX > -Infinity && maxY > -Infinity) {
+        const visibleWidth = maxX - minX;
+        const visibleHeight = maxY - minY;
+        const svgWidth = svgElement.clientWidth;
+        const svgHeight = svgElement.clientHeight;
+
+        const zoomX = viewBox.width / visibleWidth;
+        const zoomY = viewBox.height / visibleHeight;
+        currentZoom = Math.max(zoomX, zoomY);
+
+        viewBox = {
+            x: minX,
+            y: minY,
+            width: originalViewBox.width / currentZoom,
+            height: originalViewBox.height / currentZoom
+        };
+
+        updateSvgViewBox();
+        zoomFactorDisplay.textContent = `Zoom: ${currentZoom.toFixed(1)}x`;
+
+        // Adjust viewBox to fit within the current browser view area
+        const svgRect = svgElement.getBoundingClientRect();
+        const viewWidth = window.innerWidth;
+        const viewHeight = window.innerHeight;
+
+        const scaleX = viewWidth / svgRect.width;
+        const scaleY = viewHeight / svgRect.height;
+        const scale = Math.min(scaleX, scaleY);
+
+        viewBox.width *= scale;
+        viewBox.height *= scale;
+        viewBox.x -= (viewBox.width - originalViewBox.width / currentZoom) / 2;
+        viewBox.y -= (viewBox.height - originalViewBox.height / currentZoom) / 2;
+
+        updateSvgViewBox();
+
     }
 }


### PR DESCRIPTION
Introduce a new button to zoom into the visible area of SVG elements and fix the zoom calculation to reset the view appropriately.

closes #38