### PR TITLE
Enhance postal code highlighting and removal functionality

### DIFF
--- a/html/scripts/postalCodeManager.js
+++ b/html/scripts/postalCodeManager.js
@@ -221,6 +221,7 @@ function removePostalCode(postalCode) {
     if (pathElement) {
         pathElement.classList.remove('selected', 'loading', 'delivery');
         pathElement.style.fill = '';
+        highlightPostalCode(postalCode, false); // Remove highlight when postal code is removed
     }
     updatePostalCodeLists();
     saveSelectedPostalCodes();
@@ -251,7 +252,7 @@ function highlightPostalCode(postalCode, highlight) {
     if (pathElement) {
         if (highlight) {
             pathElement.style.stroke = '#ff0000';
-            pathElement.style.strokeWidth = '2px';
+            pathElement.style.strokeWidth = '4px';
             pathElement.style.fillOpacity = '0.7';
             pathElement.style.animation = 'highlight 1s infinite';
         } else {
@@ -259,7 +260,6 @@ function highlightPostalCode(postalCode, highlight) {
             pathElement.style.strokeWidth = '';
             pathElement.style.fillOpacity = '';
             pathElement.style.animation = '';
-
         }
     }
 }


### PR DESCRIPTION
Improve the removal of postal code highlights and increase the stroke width during highlighting for better visibility. Ensure highlights are cleared when a postal code is removed.

closes #84